### PR TITLE
add-global-error-handler

### DIFF
--- a/api/src/app.py
+++ b/api/src/app.py
@@ -17,3 +17,6 @@ from .routes import public, private
 app.register_blueprint(public)
 app.register_blueprint(private)
 
+
+from .utils import add_global_error_handler
+add_global_error_handler(app)

--- a/api/src/routes/private.py
+++ b/api/src/routes/private.py
@@ -372,7 +372,6 @@ def handle_student():
     """
     if request.method == 'POST':
         body = request.json
-        print(body, flush=True)
         for student in body:
             s=Student.query.filter_by(netid=student['netid']).first()
             if s is None:

--- a/api/src/routes/public.py
+++ b/api/src/routes/public.py
@@ -10,10 +10,15 @@ from ..utils import enqueue_webhook_job, log_event, get_request_ip, esindex
 public = Blueprint('public', __name__, url_prefix='/public')
 
 
+def webhook_log_msg():
+    if request.headers.get('Content-Type', None) == 'application/json' and \
+       request.headers.get('X-GitHub-Event', None) == 'push':
+        return request.json['pusher']['name']
+    return None
 
 # dont think we need GET here
 @public.route('/webhook', methods=['POST'])
-@log_event('job-request', get_request_ip)
+@log_event('job-request', webhook_log_msg)
 def webhook():
     """
     This route should be hit by the github when a push happens.
@@ -46,8 +51,6 @@ def webhook():
         student = Student.query.filter_by(
             github_username=github_username,
         ).first()
-
-        print(github_username, student, flush=True)
 
         if student is not None:
             submission.studentid=student.id

--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -11,6 +11,7 @@ from redis import Redis
 from json import dumps
 from os import environ
 from rq import Queue
+import traceback
 
 from .jobs import test_repo
 from .app import db
@@ -156,3 +157,16 @@ def jsonify(data):
     res = Response(dumps(data))
     res.headers['Content-Type'] = 'application/json'
     return res
+
+
+def add_global_error_handler(app):
+    @app.errorhandler(Exception)
+    def global_err_handler(error):
+        tb = traceback.format_exc() # get traceback string
+        esindex(
+            'error',
+            type='global-handler',
+            logs=tb,
+            submission=None,
+            netid=None,
+        )


### PR DESCRIPTION
Add a global error handler. This will store the traceback in elastic search whenever an exception occurs.