### PR TITLE
fix caching submission issue

### DIFF
--- a/api/src/routes/public.py
+++ b/api/src/routes/public.py
@@ -77,7 +77,7 @@ def handle_regrade(commit=None, netid=None):
 
 @public.route('/submissions/<commit>/<netid>')
 @log_event('submission-request', lambda: 'specifc submission requests')
-@cache.cached(timeout=2, key_prefix='web-submission-student')
+@cache.memoize(timeout=2, key_prefix='web-submission-student')
 def handle_submission(commit=None, netid=None):
     if commit is None or netid is None:
         return jsonify({


### PR DESCRIPTION
This route was cached for way too long. Students polling for submission data would have to wait for caching to break.