### PR TITLE
Make `/api` fully type checked and add support to mypy

### DIFF
--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -31,6 +31,9 @@ jobs:
         python -m pip install --upgrade pip virtualenv
         virtualenv -p $(which python3) venv
         if [ -f requirements/dev.txt ]; then ./venv/bin/pip install -r requirements/dev.txt; fi
+    - name: Run mypy
+      run: |
+        make check
     - name: Background API
       run: |
         set -x

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -5,3 +5,4 @@ env
 .data
 
 .pytest_cache
+.mypy_cache

--- a/api/Makefile
+++ b/api/Makefile
@@ -38,6 +38,7 @@ migrations: venv
 lint: venv
 	@echo 'black to stylize'
 	./venv/bin/black $(LINT_FILES)
+	./venv/bin/lint $(LINT_FILES)
 
 .PHONY: check
 check: venv				 # Run static checks without modifying files

--- a/api/Makefile
+++ b/api/Makefile
@@ -39,6 +39,10 @@ lint: venv
 	@echo 'black to stylize'
 	./venv/bin/black $(LINT_FILES)
 
+.PHONY: check
+check: venv				 # Run static checks without modifying files
+	./venv/bin/mypy --show-error-codes $(LINT_FILES)
+
 .PHONY: clean               # Clean directories
 clean:
 	rm -rf $$(find -name __pycache__) venv .data

--- a/api/anubis/k8s/pipeline.py
+++ b/api/anubis/k8s/pipeline.py
@@ -2,6 +2,7 @@ import os
 import time
 import traceback
 from datetime import datetime, timedelta
+from typing import cast
 
 import kubernetes
 from kubernetes import client
@@ -124,7 +125,7 @@ def reap_pipeline_jobs() -> int:
 
     # Iterate through all pipeline jobs
     for job in jobs.items:
-        job: client.V1Job
+        job = cast(client.V1Job, job)
 
         # Calculate job created time
         job_created = job.metadata.creation_timestamp.replace(tzinfo=None)

--- a/api/anubis/k8s/theia.py
+++ b/api/anubis/k8s/theia.py
@@ -295,6 +295,9 @@ def create_theia_k8s_pod_pvc(
         # Create a token for the session owner
         token = create_token(theia_session.owner.netid)
 
+        # The session must have a owner, so the token must exist
+        assert token is not None
+
         # Create the INCLUSTER environment variable as the base64
         # encoded token. This token should be picked up by the
         # theia init process to initialize the anubis cli with

--- a/api/anubis/k8s/theia.py
+++ b/api/anubis/k8s/theia.py
@@ -2,7 +2,7 @@ import base64
 import json
 import traceback
 from datetime import datetime, timedelta
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from kubernetes import client, config
 
@@ -449,7 +449,7 @@ def create_theia_k8s_pod_pvc(
     extra_labels = {}
 
     # Anything extra in the pod spec to be added
-    spec_extra = {}
+    spec_extra: Dict[str, Any] = {}
 
     # If network locked, then set the network policy to student
     # and dns to 1.1.1.1

--- a/api/anubis/lms/assignments.py
+++ b/api/anubis/lms/assignments.py
@@ -1,6 +1,6 @@
 import traceback
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from dateutil.parser import ParserError
 from dateutil.parser import parse as date_parse
@@ -178,7 +178,7 @@ def get_assignments(netid: str, course_id=None) -> Optional[List[Dict[str, Any]]
     return response
 
 
-def assignment_sync(assignment_data: dict) -> Tuple[Union[dict, str], bool]:
+def assignment_sync(assignment_data: dict) -> Tuple[Optional[dict], str, bool]:
     """
     Take an assignment_data dictionary from a assignment meta.yaml
     and update any and all existing data about the assignment.
@@ -200,7 +200,7 @@ def assignment_sync(assignment_data: dict) -> Tuple[Union[dict, str], bool]:
         )
     ).first()
     if course is None:
-        return "Unable to find course", False
+        return None, "Unable to find course", False
 
     assert_course_admin(course.id)
 
@@ -226,7 +226,7 @@ def assignment_sync(assignment_data: dict) -> Tuple[Union[dict, str], bool]:
         assignment.grace_date = date_parse(assignment_data["date"]["grace"])
     except ParserError:
         logger.error(traceback.format_exc())
-        return "Unable to parse datetime", False
+        return None, "Unable to parse datetime", False
 
     db.session.add(assignment)
 
@@ -279,7 +279,7 @@ def assignment_sync(assignment_data: dict) -> Tuple[Union[dict, str], bool]:
     # Commit changes
     db.session.commit()
 
-    return {"assignment": assignment.data, "questions": question_message}, True
+    return {"assignment": assignment.data, "questions": question_message}, "", True
 
 
 def fill_user_assignment_data(user_id: str, assignment_data: Dict[str, Any]):

--- a/api/anubis/lms/assignments.py
+++ b/api/anubis/lms/assignments.py
@@ -226,7 +226,7 @@ def assignment_sync(assignment_data: dict) -> Tuple[Union[dict, str], bool]:
         assignment.grace_date = date_parse(assignment_data["date"]["grace"])
     except ParserError:
         logger.error(traceback.format_exc())
-        return "Unable to parse datetime", 406
+        return "Unable to parse datetime", False
 
     db.session.add(assignment)
 

--- a/api/anubis/lms/courses.py
+++ b/api/anubis/lms/courses.py
@@ -119,7 +119,7 @@ def get_course_context(full_stop: bool = True) -> Union[None, Course]:
     return g.course_context
 
 
-def is_course_superuser(course_id: str, user_id: str = None) -> bool:
+def is_course_superuser(course_id: Optional[str], user_id: str = None) -> bool:
     """
     Use this function to verify if the current user is a superuser for
     the specified course_id. A user is a superuser for a course if they are
@@ -129,6 +129,10 @@ def is_course_superuser(course_id: str, user_id: str = None) -> bool:
     :param user_id:
     :return:
     """
+
+    # If the `course_id` does not exist at all
+    if course_id is None:
+        return False
 
     # Get the current user
     if user_id is None:
@@ -150,7 +154,7 @@ def is_course_superuser(course_id: str, user_id: str = None) -> bool:
     return prof is not None
 
 
-def is_course_admin(course_id: str, user_id: str = None) -> bool:
+def is_course_admin(course_id: Optional[str], user_id: str = None) -> bool:
     """
     Use this function to verify if the current user is an admin for
     the specified course_id. A user is an admin for a course if they are
@@ -160,6 +164,10 @@ def is_course_admin(course_id: str, user_id: str = None) -> bool:
     :param user_id:
     :return:
     """
+
+    # If the `course_id` does not exist at all
+    if course_id is None:
+        return False
 
     # Get the current user
     if user_id is None:

--- a/api/anubis/lms/courses.py
+++ b/api/anubis/lms/courses.py
@@ -15,6 +15,7 @@ from anubis.models import (
     AssignmentQuestion,
     AssignmentRepo,
     AssignmentTest,
+    BaseModel,
     Course,
     InCourse,
     LateException,
@@ -225,7 +226,7 @@ def assert_course_superuser(course_id: str = None):
         raise LackCourseContext("Requires course Professor permissions")
 
 
-def assert_course_context(*models: Tuple[Any]):
+def assert_course_context(*models: BaseModel):
     """
     This function checks that all the sqlalchemy objects that are
     passed to this function are within the current course context.

--- a/api/anubis/lms/courses.py
+++ b/api/anubis/lms/courses.py
@@ -239,6 +239,10 @@ def assert_course_context(*models: BaseModel):
     # Get the current course context
     context = get_course_context()
 
+    # This check does not make sense when the context is None
+    if context is None:
+        raise LackCourseContext("Cannot find the course context")
+
     # Create a stack of objects to check
     object_stack = list(models)
 

--- a/api/anubis/lms/courses.py
+++ b/api/anubis/lms/courses.py
@@ -291,7 +291,7 @@ def assert_course_context(*models: BaseModel):
             LateException,
         ]:
             if isinstance(model, model_type):
-                object_stack.append(model.assignment)
+                object_stack.append(model.assignment)  # type: ignore[attr-defined] # Typing for backref is currently not supported
                 continue
 
         # Group together all the models that have a course
@@ -303,7 +303,7 @@ def assert_course_context(*models: BaseModel):
             LectureNotes,
         ]:
             if isinstance(model, model_type):
-                object_stack.append(model.course)
+                object_stack.append(model.course)  # type: ignore[attr-defined] # Typing for backref is currently not supported
                 continue
 
         # ---------------------------------
@@ -710,4 +710,4 @@ def add_all_users_to_course(users: List[User], course: Course) -> int:
     return len(all_not_in_course)
 
 
-course_context: Course = LocalProxy(get_course_context)
+course_context: Course = LocalProxy(get_course_context)  # type: ignore[assignment] # Skip type-check for proxy objects

--- a/api/anubis/lms/questions.py
+++ b/api/anubis/lms/questions.py
@@ -1,7 +1,7 @@
 import io
 import random
 import zipfile
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import yaml
 
@@ -41,7 +41,7 @@ def get_question_pool_mapping(
     pools = set(question.pool for question in questions)
 
     # Build up sequence to question mapping
-    sequence_to_questions = {pool: [] for pool in pools}
+    sequence_to_questions: Dict[int, List[AssignmentQuestion]] = {pool: [] for pool in pools}
     for question in questions:
         sequence_to_questions[question.pool].append(question)
 
@@ -154,7 +154,7 @@ def assign_questions(assignment: Assignment):
     return assigned_questions
 
 
-def ingest_questions(questions: dict, assignment: Assignment):
+def ingest_questions(questions: List[Any], assignment: Assignment):
     """
     questions: [
       {

--- a/api/anubis/lms/questions.py
+++ b/api/anubis/lms/questions.py
@@ -190,6 +190,9 @@ def ingest_questions(questions: dict, assignment: Assignment):
     for question_sequence in questions:
         shape_good, err_path = _verify_data_shape(question_sequence, question_shape)
         if not shape_good:
+            # When the shape is not good, err_path will never be None
+            assert err_path is not None
+
             # Reject the question if the shape is bad and continue
             rejected.append(
                 {

--- a/api/anubis/models/__init__.py
+++ b/api/anubis/models/__init__.py
@@ -27,7 +27,7 @@ THEIA_DEFAULT_OPTIONS = {
 }
 
 
-def default_id(max_len=None) -> db.Column:
+def default_id(max_len=None) -> db.Column:  # type: ignore[name-defined] # `Column` is monkey-patched to the db object
     return db.Column(db.String(128), primary_key=True, default=lambda: rand(max_len or 32))
 
 
@@ -773,13 +773,13 @@ class StaticFile(BaseModel):
 
     lecture_notes = db.relationship("LectureNotes", cascade="all,delete", backref="static_file")
 
-    @hybrid_property
+    @hybrid_property # type:ignore[no-redef]
     def blob(self):
         if isinstance(self._blob, InstrumentedAttribute):
             return self._blob
         return gzip.decompress(self._blob)
 
-    @blob.setter
+    @blob.setter # type:ignore[no-redef]
     def blob(self, blob):
         if isinstance(blob, str):
             self._blob = gzip.compress(blob.encode())

--- a/api/anubis/models/__init__.py
+++ b/api/anubis/models/__init__.py
@@ -5,6 +5,7 @@ import gzip
 from datetime import datetime, timedelta
 
 from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy.model import DefaultMeta
 from sqlalchemy.orm import deferred
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy_json import MutableJson
@@ -13,6 +14,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 from anubis.utils.data import rand
 
 db = SQLAlchemy()
+BaseModel: DefaultMeta = db.Model
 
 THEIA_DEFAULT_OPTIONS = {
     "autosave": True,
@@ -29,7 +31,7 @@ def default_id(max_len=None) -> db.Column:
     return db.Column(db.String(128), primary_key=True, default=lambda: rand(max_len or 32))
 
 
-class Config(db.Model):
+class Config(BaseModel):
     __tablename__ = "anubis_config"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -45,7 +47,7 @@ class Config(db.Model):
         }
 
 
-class User(db.Model):
+class User(BaseModel):
     __tablename__ = "user"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -91,7 +93,7 @@ class User(db.Model):
         return f"<User {self.netid} {self.github_username}>"
 
 
-class Course(db.Model):
+class Course(BaseModel):
     __tablename__ = "course"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -153,7 +155,7 @@ class Course(db.Model):
         }
 
 
-class TAForCourse(db.Model):
+class TAForCourse(BaseModel):
     __tablename__ = "ta_for_course"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -169,7 +171,7 @@ class TAForCourse(db.Model):
         }
 
 
-class ProfessorForCourse(db.Model):
+class ProfessorForCourse(BaseModel):
     __tablename__ = "professor_for_course"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -185,7 +187,7 @@ class ProfessorForCourse(db.Model):
         }
 
 
-class InCourse(db.Model):
+class InCourse(BaseModel):
     __tablename__ = "in_course"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -194,7 +196,7 @@ class InCourse(db.Model):
     course_id = db.Column(db.String(128), db.ForeignKey(Course.id), primary_key=True)
 
 
-class Assignment(db.Model):
+class Assignment(BaseModel):
     __tablename__ = "assignment"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -275,7 +277,7 @@ class Assignment(db.Model):
         return data
 
 
-class AssignmentRepo(db.Model):
+class AssignmentRepo(BaseModel):
     __tablename__ = "assignment_repo"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -313,7 +315,7 @@ class AssignmentRepo(db.Model):
         }
 
 
-class AssignmentTest(db.Model):
+class AssignmentTest(BaseModel):
     __tablename__ = "assignment_test"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -332,7 +334,7 @@ class AssignmentTest(db.Model):
         return {"id": self.id, "name": self.name, "hidden": self.hidden}
 
 
-class AssignmentQuestion(db.Model):
+class AssignmentQuestion(BaseModel):
     __tablename__ = "assignment_question"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -378,7 +380,7 @@ class AssignmentQuestion(db.Model):
         }
 
 
-class AssignedStudentQuestion(db.Model):
+class AssignedStudentQuestion(BaseModel):
     __tablename__ = "assigned_student_question"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -435,7 +437,7 @@ class AssignedStudentQuestion(db.Model):
         return data
 
 
-class AssignedQuestionResponse(db.Model):
+class AssignedQuestionResponse(BaseModel):
     __tablename__ = "assigned_student_response"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -468,7 +470,7 @@ class AssignedQuestionResponse(db.Model):
         }
 
 
-class Submission(db.Model):
+class Submission(BaseModel):
     __tablename__ = "submission"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -540,7 +542,7 @@ class Submission(db.Model):
         return data
 
 
-class SubmissionTestResult(db.Model):
+class SubmissionTestResult(BaseModel):
     __tablename__ = "submission_test_result"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -589,7 +591,7 @@ class SubmissionTestResult(db.Model):
         )
 
 
-class SubmissionBuild(db.Model):
+class SubmissionBuild(BaseModel):
     __tablename__ = "submission_build"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -621,7 +623,7 @@ class SubmissionBuild(db.Model):
         return data
 
 
-class TheiaImage(db.Model):
+class TheiaImage(BaseModel):
     __tablename__ = "theia_image"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -652,7 +654,7 @@ class TheiaImage(db.Model):
         }
 
 
-class TheiaImageTag(db.Model):
+class TheiaImageTag(BaseModel):
     __tablename__ = 'theia_image_tag'
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -675,7 +677,7 @@ class TheiaImageTag(db.Model):
         }
 
 
-class TheiaSession(db.Model):
+class TheiaSession(BaseModel):
     __tablename__ = "theia_session"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -751,7 +753,7 @@ class TheiaSession(db.Model):
         }
 
 
-class StaticFile(db.Model):
+class StaticFile(BaseModel):
     __tablename__ = "static_file"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -798,7 +800,7 @@ class StaticFile(db.Model):
         }
 
 
-class LateException(db.Model):
+class LateException(BaseModel):
     __tablename__ = "late_exception"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 
@@ -823,7 +825,7 @@ class LateException(db.Model):
         }
 
 
-class LectureNotes(db.Model):
+class LectureNotes(BaseModel):
     __tablename__ = "lecture_notes"
     __table_args__ =  {'mysql_charset': 'utf8mb4', 'mysql_collate': 'utf8mb4_general_ci'}
 

--- a/api/anubis/utils/auth/user.py
+++ b/api/anubis/utils/auth/user.py
@@ -81,4 +81,4 @@ def _create_get_current_user_field(field: str) -> Callable:
     return _func
 
 
-current_user: User = LocalProxy(get_current_user)
+current_user: User = LocalProxy(get_current_user)  # type: ignore[assignment] # Skip type-check for proxy objects

--- a/api/anubis/utils/data.py
+++ b/api/anubis/utils/data.py
@@ -125,7 +125,7 @@ def _verify_data_shape(data, shape, path=None) -> Tuple[bool, Union[str, None]]:
       {'data': list}
     ) -> (False, '.data')
 
-    :return: success as bool, error path
+    :return: success as bool, error path (None if success is True, str otherwise)
     """
 
     if path is None:

--- a/api/anubis/utils/data.py
+++ b/api/anubis/utils/data.py
@@ -49,7 +49,7 @@ def jsonify(data, status_code=200):
     return res
 
 
-def send_noreply_email(message: str, subject: str, recipient: str):
+def send_noreply_email(message_raw: str, subject: str, recipient: str):
     """
     Use this function to send a noreply email to a user (ie student).
 
@@ -69,9 +69,9 @@ def send_noreply_email(message: str, subject: str, recipient: str):
     """
 
     if environ.get("DEBUG", False):
-        return print(message, subject, recipient, flush=True)
+        return print(message_raw, subject, recipient, flush=True)
 
-    message = MIMEText(message, "plain")
+    message = MIMEText(message_raw, "plain")
     message["Subject"] = subject
 
     message["From"] = "noreply@anubis.osiris.services"
@@ -256,8 +256,8 @@ def human_readable_to_bytes(size: str) -> int:
     :return:
     """
     size_name = ("B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB")
-    size = size.split()  # divide '1 GB' into ['1', 'GB']
-    num, unit = int(size[0]), size[1]
+    sizes = size.split()  # divide '1 GB' into ['1', 'GB']
+    num, unit = int(sizes[0]), sizes[1]
     # index in list of sizes determines power to raise it to
     idx = size_name.index(unit)
     # ** is the "exponent" operator - you can use it instead of math.pow()

--- a/api/anubis/utils/exceptions.py
+++ b/api/anubis/utils/exceptions.py
@@ -55,18 +55,18 @@ def add_app_exception_handlers(app: Flask):
     from anubis.utils.logging import logger
 
     # Set AuthenticationError handler
-    @app.errorhandler(AuthenticationError)
+    @app.errorhandler(AuthenticationError)  # type: ignore[arg-type] # Flask errorhandler does not support type inference for callables
     def handler_authentication_error(e: AuthenticationError):
         logger.error(traceback.format_exc())
         return jsonify(error_response(str(e) or "Unauthenticated")), 401
 
     # Set LackCourseContext handler
-    @app.errorhandler(LackCourseContext)
+    @app.errorhandler(LackCourseContext)  # type: ignore[arg-type] # Flask errorhandler does not support type inference for callables
     def handle_lack_course_context(e: LackCourseContext):
         logger.error(traceback.format_exc())
         return jsonify(error_response(str(e) or "Please set your course context"))
 
-    @app.errorhandler(AssertError)
+    @app.errorhandler(AssertError)  # type: ignore[arg-type] # Flask errorhandler does not support type inference for callables
     def handle_assertion_error(e: AssertError):
         logger.error(traceback.format_exc())
         message, status_code = e.response()

--- a/api/anubis/utils/github/fix.py
+++ b/api/anubis/utils/github/fix.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import List
+from typing import Any, Dict, List
 
 from sqlalchemy.sql import or_
 
@@ -77,7 +77,7 @@ def fix_github_missing_submissions(org_name: str):
     repositories = organization["repositories"]["nodes"]
 
     # Running map of unique_code -> assignment objects
-    assignments = dict()
+    assignments: Dict[str, Any] = dict()
 
     # Parse out repo name and url from graphql response
     repos = map(lambda node: (node["name"], node["url"], node["ref"]), repositories)

--- a/api/anubis/utils/github/repos.py
+++ b/api/anubis/utils/github/repos.py
@@ -295,13 +295,13 @@ def create_assignment_github_repo(
             # for creating a repo from the template.
             data = get_github_template_ids(template_repo_path, github_org)
 
-            # If the response was None, the api request failed. Also check that
-            # some expected values are present in the json data response.
-            if data is None and "repository" in data and "id" in data["repository"]:
+            # If the response was None, the api request failed. No further checks
+            # in the json data response since it is None already.
+            if data is None:
                 for repo in repos:
                     repo.repo_created = False
                 db.session.commit()
-                return repos
+                return repo
 
             # Get organization and template repo IDs
             owner_id = data["organization"]["id"]

--- a/api/anubis/utils/http/__init__.py
+++ b/api/anubis/utils/http/__init__.py
@@ -82,26 +82,24 @@ def get_number_arg(arg_name: str = "number", default_value: int = 10, reject_neg
     :return:
     """
 
-    # Get the query argument in string form
-    n_str: str = request.args.get(arg_name, default=default_value)
+    # Get the query argument, attempt to convert it
+    # to an int with the built-in `type` argument,
+    # and fallback to default when it fails to convert.
+    n = request.args.get(arg_name, default=default_value, type=int)
 
-    try:
-        # Attempt to convert to a python int
-        n: int = int(n_str)
+    # Type conversion to int fails when arg_name is None
+    # and we fallback to default in that case,
+    # so n can never be None.
+    assert n is not None
 
-        # If reject_negative, then check if
-        # the parsed value is negative.
-        if reject_negative and n < 0:
-            # If it was negative, then fallback to default
-            return default_value
-
-        # Return integer value
-        return n
-    except ValueError:
-        # ValueError is raised if the string to int
-        # conversion was unsuccessful. In that case,
-        # then we fallback to default
+    # If reject_negative, then check if
+    # the parsed value is negative.
+    if reject_negative and n < 0:
+        # If it was negative, then fallback to default
         return default_value
+
+    # Return integer value
+    return n
 
 
 def get_request_file_stream(

--- a/api/anubis/utils/http/__init__.py
+++ b/api/anubis/utils/http/__init__.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Tuple, Union
+from typing import Literal, Tuple, Union, overload
 
 from flask import request
 from werkzeug.utils import secure_filename
@@ -102,6 +102,18 @@ def get_number_arg(arg_name: str = "number", default_value: int = 10, reject_neg
     return n
 
 
+@overload
+def get_request_file_stream(with_filename: Literal[False], fail_ok: bool = False) -> Union[bytes, None]:
+    ...
+
+
+@overload
+def get_request_file_stream(
+    with_filename: Literal[True], fail_ok: bool = False
+) -> Union[Tuple[bytes, str], Tuple[None, None]]:
+    ...
+
+
 def get_request_file_stream(
     with_filename=False, fail_ok=False
 ) -> Union[bytes, None, Tuple[bytes, str], Tuple[None, None]]:
@@ -126,7 +138,7 @@ def get_request_file_stream(
 
     # If they want the filename too
     if with_filename:
-        return file.stream.read(), secure_filename(file.filename)
+        return file.stream.read(), secure_filename(file.filename if file.filename is not None else "")
 
     # Read its stream
     return file.stream.read()

--- a/api/anubis/utils/http/decorators.py
+++ b/api/anubis/utils/http/decorators.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import List, Tuple, Union
+from typing import Iterable, List, Tuple, Union
 
 from flask import request
 
@@ -78,7 +78,7 @@ def json_response(func):
 
 
 def json_endpoint(
-    required_fields: Union[List[str], List[Tuple], None] = None,
+    required_fields: Union[Iterable[str], Iterable[Tuple], None] = None,
     only_required: bool = False,
 ):
     """

--- a/api/anubis/utils/http/files.py
+++ b/api/anubis/utils/http/files.py
@@ -68,6 +68,9 @@ def process_file_upload() -> StaticFile:
     # Make sure we got a file
     req_assert(stream is not None, message="No file uploaded")
 
+    # stream is not None with `req_assert`
+    assert stream is not None
+
     # Figure out content type
     mime_type = get_mime_type(stream)
 

--- a/api/anubis/utils/testing/autograde_timings.py
+++ b/api/anubis/utils/testing/autograde_timings.py
@@ -1,7 +1,7 @@
 import time
 
 from anubis.lms.autograde import bulk_autograde
-from anubis.models import db
+from anubis.models import db, TheiaImage
 from anubis.utils.data import with_context
 from anubis.utils.testing.seed import create_assignment, create_course, create_students, init_submissions
 from anubis.utils.testing.db import clear_database
@@ -9,6 +9,11 @@ from anubis.utils.testing.db import clear_database
 
 def do_seed() -> str:
     clear_database()
+
+    xv6_image = TheiaImage(image="registry.digitalocean.com/anubis/theia-xv6")
+    db.session.add(xv6_image)
+
+    db.session.commit()
 
     # OS test course
     intro_to_os_students = create_students(100)
@@ -24,6 +29,7 @@ def do_seed() -> str:
     os_assignment0, _, os_submissions0, _ = create_assignment(
         intro_to_os_course,
         intro_to_os_students,
+        xv6_image,
         i=0,
         github_repo_required=True,
         submission_count=50,

--- a/api/anubis/utils/testing/seed.py
+++ b/api/anubis/utils/testing/seed.py
@@ -178,7 +178,7 @@ def create_assignment(
 
 
 def create_students(n=10) -> List[User]:
-    students = []
+    students: List[User] = []
     netids = set()
     while len(students) < n:
 

--- a/api/anubis/utils/visuals/assignments.py
+++ b/api/anubis/utils/visuals/assignments.py
@@ -70,10 +70,10 @@ def get_assignment_tests_pass_times(assignment_test: AssignmentTest):
     )
 
     # Drop outlier values (> 3 sigma)
-    df = df[np.abs(df.duration - df.duration.mean()) <= (3 * df.duration.std())].value_counts().to_dict()
+    df_dict = df[np.abs(df.duration - df.duration.mean()) <= (3 * df.duration.std())].value_counts().to_dict()
 
     # Return the x and y plot data for the scatter visual
-    return [{"x": np.abs(x[0]), "y": y, "size": 3} for x, y in df.items()]
+    return [{"x": np.abs(x[0]), "y": y, "size": 3} for x, y in df_dict.items()]
 
 
 def get_assignment_tests_pass_counts(assignment_test: AssignmentTest):

--- a/api/anubis/utils/visuals/usage.py
+++ b/api/anubis/utils/visuals/usage.py
@@ -131,7 +131,7 @@ def get_raw_submissions() -> List[Dict[str, Any]]:
 
 
 @cache.memoize(timeout=-1, forced_update=is_job, unless=is_debug)
-def get_usage_plot(course_id: Optional[str]) -> Optional[bytes]:
+def get_usage_plot(course_id: str) -> Optional[bytes]:
     import matplotlib.colors as mcolors
     import matplotlib.pyplot as plt
 

--- a/api/anubis/views/admin/assignments.py
+++ b/api/anubis/views/admin/assignments.py
@@ -496,10 +496,10 @@ def private_assignment_sync(assignment: dict):
     # The course context assertion happens in the sync function
 
     # Create or update assignment
-    message, success = assignment_sync(assignment)
+    data, message, success = assignment_sync(assignment)
 
     # If there was an error, pass it back
     req_assert(success, message=message, status_code=406)
 
     # Return
-    return success_response(message)
+    return success_response(data)

--- a/api/anubis/views/admin/ide.py
+++ b/api/anubis/views/admin/ide.py
@@ -114,7 +114,7 @@ def admin_ide_initialize_custom(settings: dict, **_):
         message="Starting new IDEs is currently disabled by an Anubis administrator. " "Please try again later.",
     )
 
-    session: TheiaSession = initialize_ide(
+    session = initialize_ide(
         image_id=image.id,
 
         assignment_id=None,

--- a/api/anubis/views/admin/ide.py
+++ b/api/anubis/views/admin/ide.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from flask import Blueprint
 
@@ -92,10 +92,11 @@ def admin_ide_initialize_custom(settings: dict, **_):
     persistent_storage = settings.get("persistent_storage", False)
 
     image_id = image.get('id', None)
+    image_db: Optional[TheiaImage] = None
     if image_id is not None:
-        image: TheiaImage = TheiaImage.query.filter(TheiaImage.id == image_id).first()
-    if image is None or image == dict():
-        image: TheiaImage = default_image
+        image_db = TheiaImage.query.filter(TheiaImage.id == image_id).first()
+    if image_db is None or image == dict():
+        image_db = default_image
 
     # Attempt to load the options_str into a dict object
     try:
@@ -115,7 +116,7 @@ def admin_ide_initialize_custom(settings: dict, **_):
     )
 
     session = initialize_ide(
-        image_id=image.id,
+        image_id=image_db.id,
 
         assignment_id=None,
         course_id=course_context.id,

--- a/api/anubis/views/admin/late_exceptions.py
+++ b/api/anubis/views/admin/late_exceptions.py
@@ -91,6 +91,8 @@ def admin_late_exception_update(assignment_id: str = None, user_id: str = None, 
 
     # Try to parse the datetime
     try:
+        if due_date is None:
+            raise ParserError
         due_date = date_parse(due_date)
     except ParserError:
         return error_response("datetime could not be parsed")

--- a/api/anubis/views/admin/late_exceptions.py
+++ b/api/anubis/views/admin/late_exceptions.py
@@ -93,16 +93,16 @@ def admin_late_exception_update(assignment_id: str = None, user_id: str = None, 
     try:
         if due_date is None:
             raise ParserError
-        due_date = date_parse(due_date)
+        parsed_due_date = date_parse(due_date)
     except ParserError:
         return error_response("datetime could not be parsed")
 
     # Double check that the new due data is not before the actual deadline
-    if due_date <= assignment.due_date:
+    if parsed_due_date <= assignment.due_date:
         return error_response("Exception cannot be before assignment due date")
 
     # Update the due date
-    late_exception.due_date = due_date
+    late_exception.due_date = parsed_due_date
 
     db.session.commit()
 

--- a/api/anubis/views/admin/lectures.py
+++ b/api/anubis/views/admin/lectures.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from dateutil.parser import parse as date_parse
 from flask import Blueprint, request
@@ -94,14 +95,14 @@ def admin_lecture_save(lecture_notes_id: str):
     """
 
     # Get fields from params
-    post_time = request.args.get("post_time", default=None)
+    post_time_str = request.args.get("post_time", default=None)
     title = request.args.get("title", default="")
     description = request.args.get("description", default="")
 
     # If post time was in the http query, then try to parse it
-    if isinstance(post_time, str):
+    if isinstance(post_time_str, str):
         try:
-            post_time = date_parse(post_time)
+            post_time: Optional[datetime] = date_parse(post_time_str)
         except:
             post_time = None
 

--- a/api/anubis/views/pipeline/pipeline.py
+++ b/api/anubis/views/pipeline/pipeline.py
@@ -173,7 +173,7 @@ def pipeline_report_test(submission: Submission, test_name: str, passed: bool, m
     # Update the fields
     submission_test_result.passed = passed
     submission_test_result.message = message
-    submission_test_result.stdout = stdout
+    submission_test_result.stdout = stdout # type:ignore[assignment]
 
     # Add and commit
     db.session.add(submission_test_result)

--- a/api/anubis/views/pipeline/pipeline.py
+++ b/api/anubis/views/pipeline/pipeline.py
@@ -255,6 +255,9 @@ def pipeline_report_state(submission: Submission, state: str, **kwargs):
     if not hidden_test:
         submission.state = state
 
+    # We have checked that `request.json` is not None with `json_endpoint` already
+    assert request.json is not None
+
     # If processed was specified and is of type bool, then update that too
     if "processed" in request.json and isinstance(request.json["processed"], bool):
         submission.processed = request.json["processed"]

--- a/api/anubis/views/public/webhook.py
+++ b/api/anubis/views/public/webhook.py
@@ -33,6 +33,9 @@ def webhook_log_msg() -> Union[str, None]:
     # If the content type is json, and the github event was a push,
     # then log the repository name
     if content_type == "application/json" and x_github_event == "push":
+        # request.json cannot be None when the content type is json
+        assert request.json is not None
+
         return request.json.get("repository", {}).get("name", None)
 
     return None

--- a/api/anubis/views/super/ide.py
+++ b/api/anubis/views/super/ide.py
@@ -51,9 +51,9 @@ def super_ide_images_save(images: list):
 
     db.session.commit()
 
-    images: List[TheiaImage] = TheiaImage.query.populate_existing().all()
+    images_db: List[TheiaImage] = TheiaImage.query.populate_existing().all()
     return success_response({
-        'images': [image.data for image in images],
+        'images': [image.data for image in images_db],
         'status': 'Images saved',
     })
 

--- a/api/jobs/bot.py
+++ b/api/jobs/bot.py
@@ -195,7 +195,7 @@ def generate_ide_report(day=None, mobile: bool = False) -> Union[discord.Embed, 
         ("ID", "Age", "Last Proxy")
     )
 
-    report = (
+    report_raw = (
         "IDEs Active ({})\n{}\n\nIDE Time Served Today: {}\nIDE Time Served Total: {}"
     ).format(
         len(active_ides),
@@ -204,22 +204,22 @@ def generate_ide_report(day=None, mobile: bool = False) -> Union[discord.Embed, 
         human_readable_datetime(total_ide_seconds)
     )
 
-    print(report)
+    print(report_raw)
     if mobile:
         if len(active_ides) > 20:
-            report = report.split("\n")
+            report = report_raw.split("\n")
             r1 = to_image("\n".join(report[:len(report) // 2]))
             r2 = to_image("\n".join(report[len(report) // 2:]))
             reportImg = Image.new("RGB", (r1.width + r2.width, max(r1.height, r2.height)))
             reportImg.paste(r1, (0, 0))
             reportImg.paste(r2, (r1.width, 0))
         else:
-            reportImg = to_image(report)
+            reportImg = to_image(report_raw)
         return reportImg
     return discord.Embed(
         title="IDE report",
-        description="```" + report + "```"
-    ).set_thumbnail(url=bot.user.avatar_url).set_author(name="Anubis Bot")
+        description="```" + report_raw + "```"
+    ).set_thumbnail(url=str(bot.user.avatar_url)).set_author(name="Anubis Bot")
 
 
 bot = commands.Bot(

--- a/api/migrations/env.py
+++ b/api/migrations/env.py
@@ -29,6 +29,8 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
+# Something must has gone wrong if `config_file_name` is None
+assert config.config_file_name is not None
 fileConfig(config.config_file_name, disable_existing_loggers=False)
 logger = logging.getLogger("alembic.env")
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -4,3 +4,31 @@ line-length = 120
 [tool.isort]
 line_length = 120
 profile = "black"
+
+[tool.mypy]
+# We want to skip type check for automatically generated files
+exclude = "venv"
+plugins = [
+    "kubernetes_typed.plugin",
+]
+no_implicit_reexport = false
+namespace_packages = true
+
+[[tool.mypy.overrides]]
+# Skip certain modules that haven't yet been typed or provided stubs
+module = [
+    "sqlalchemy.*",
+    "sqlalchemy_json.*",
+    "parse",
+    "flask_sqlalchemy.*",
+    "flask_migrate.*",
+    "flask_caching.*",
+    "flask_oauthlib.*",
+    "alembic.*",
+    "rq.*",
+    "matplotlib.*",
+    "magic.*",
+    "numpy.*",
+    "PIL.*"
+]
+ignore_missing_imports = true

--- a/api/requirements/common.txt
+++ b/api/requirements/common.txt
@@ -72,6 +72,10 @@ idna==3.3
     # via
     #   requests
     #   yarl
+importlib-metadata==4.8.1
+    # via alembic
+importlib-resources==5.4.0
+    # via alembic
 itsdangerous==2.0.1
     # via flask
 jinja2==3.0.2
@@ -185,6 +189,10 @@ werkzeug==2.0.2
     # via flask
 yarl==1.7.2
     # via aiohttp
+zipp==3.6.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/api/requirements/dev.in
+++ b/api/requirements/dev.in
@@ -11,3 +11,17 @@ pip-tools
 
 # Python testing framework
 pytest
+mypy==0.910
+
+# Third-party stubs for mypy
+types-PyYAML
+types-python-dateutil
+types-redis
+types-requests
+types-setuptools
+types-toml
+types-tabulate
+discord.py-stubs
+discord-ext-typed-commands
+kubernetes-typed
+pandas-stubs

--- a/api/requirements/dev.txt
+++ b/api/requirements/dev.txt
@@ -20,6 +20,7 @@ attrs==21.2.0
     # via
     #   -r requirements/common.txt
     #   aiohttp
+    #   jsonschema
     #   pytest
 black==21.9b0
     # via -r requirements/dev.in
@@ -61,8 +62,15 @@ cycler==0.11.0
     # via
     #   -r requirements/common.txt
     #   matplotlib
+discord-ext-typed-commands==1.0.3
+    # via -r requirements/dev.in
 discord.py==1.7.3
-    # via -r requirements/common.txt
+    # via
+    #   -r requirements/common.txt
+    #   discord-ext-typed-commands
+    #   discord.py-stubs
+discord.py-stubs==1.7.3
+    # via -r requirements/dev.in
 docker==5.0.3
     # via -r requirements/common.txt
 flask==2.0.2
@@ -100,6 +108,14 @@ idna==3.3
     #   -r requirements/common.txt
     #   requests
     #   yarl
+importlib-metadata==4.8.1
+    # via
+    #   -r requirements/common.txt
+    #   alembic
+importlib-resources==5.4.0
+    # via
+    #   -r requirements/common.txt
+    #   alembic
 iniconfig==1.1.1
     # via pytest
 isort==5.10.0
@@ -112,12 +128,18 @@ jinja2==3.0.2
     # via
     #   -r requirements/common.txt
     #   flask
+jsonschema==4.1.2
+    # via jsonschema-typed-v2
+jsonschema-typed-v2==0.8.0
+    # via kubernetes-typed
 kiwisolver==1.3.2
     # via
     #   -r requirements/common.txt
     #   matplotlib
 kubernetes==19.15.0
     # via -r requirements/common.txt
+kubernetes-typed==18.20.0
+    # via -r requirements/dev.in
 limits==1.5.1
     # via
     #   -r requirements/common.txt
@@ -138,8 +160,17 @@ multidict==5.2.0
     #   -r requirements/common.txt
     #   aiohttp
     #   yarl
+mypy==0.910
+    # via
+    #   -r requirements/dev.in
+    #   discord.py-stubs
+    #   jsonschema-typed-v2
+    #   kubernetes-typed
 mypy-extensions==0.4.3
-    # via black
+    # via
+    #   black
+    #   kubernetes-typed
+    #   mypy
 numpy==1.21.3
     # via
     #   -r requirements/common.txt
@@ -154,6 +185,8 @@ packaging==21.0
     # via pytest
 pandas==1.3.4
     # via -r requirements/common.txt
+pandas-stubs==1.2.0.35
+    # via -r requirements/dev.in
 parse==1.19.0
     # via -r requirements/common.txt
 pathspec==0.9.0
@@ -194,6 +227,8 @@ pyparsing==3.0.4
     #   -r requirements/common.txt
     #   matplotlib
     #   packaging
+pyrsistent==0.18.0
+    # via jsonschema
 pytest==6.2.5
     # via -r requirements/dev.in
 python-dateutil==2.8.2
@@ -214,6 +249,7 @@ pyyaml==6.0
     # via
     #   -r requirements/common.txt
     #   kubernetes
+    #   kubernetes-typed
 redis==3.5.3
     # via
     #   -r requirements/common.txt
@@ -257,16 +293,34 @@ sqlalchemy-json==0.4.0
 tabulate==0.8.9
     # via -r requirements/common.txt
 toml==0.10.2
-    # via pytest
+    # via
+    #   mypy
+    #   pytest
 tomli==1.2.1
     # via
     #   black
     #   pep517
+types-python-dateutil==2.8.2
+    # via -r requirements/dev.in
+types-pyyaml==6.0.0
+    # via -r requirements/dev.in
+types-redis==3.5.15
+    # via -r requirements/dev.in
+types-requests==2.25.11
+    # via -r requirements/dev.in
+types-setuptools==57.4.2
+    # via -r requirements/dev.in
+types-tabulate==0.8.3
+    # via -r requirements/dev.in
+types-toml==0.10.1
+    # via -r requirements/dev.in
 typing-extensions==3.10.0.2
     # via
     #   -r requirements/common.txt
     #   aiohttp
     #   black
+    #   discord.py-stubs
+    #   mypy
 urllib3==1.26.7
     # via
     #   -r requirements/common.txt
@@ -287,6 +341,11 @@ yarl==1.7.2
     # via
     #   -r requirements/common.txt
     #   aiohttp
+zipp==3.6.0
+    # via
+    #   -r requirements/common.txt
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/api/tests/test_assignments_admin.py
+++ b/api/tests/test_assignments_admin.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-from utils import Session, permission_test
+from tests.utils import Session, permission_test
 
 sample_sync = {
     "name": "CS-UY 3224 TEST ADMIN",

--- a/api/tests/test_assignments_public.py
+++ b/api/tests/test_assignments_public.py
@@ -1,7 +1,7 @@
 import copy
 from datetime import datetime, timedelta
 
-from utils import Session
+from tests.utils import Session
 
 sample_sync = {
     "name": "CS-UY 3224 TEST PUBLIC HIDDEN 1",

--- a/api/tests/test_assignments_public.py
+++ b/api/tests/test_assignments_public.py
@@ -24,7 +24,7 @@ sample_sync_2 = copy.deepcopy(sample_sync)
 sample_sync_2["name"] = "CS-UY 3224 TEST PUBLIC HIDDEN 2"
 sample_sync_2["hidden"] = False
 sample_sync_2["unique_code"] = "aaaaa2"
-sample_sync_2["date"]["release"] = str(datetime.now() + timedelta(hours=2))
+sample_sync_2["date"]["release"] = str(datetime.now() + timedelta(hours=2))  # type: ignore[index]
 
 
 def create_hidden_assignments():

--- a/api/tests/test_autograde_admin.py
+++ b/api/tests/test_autograde_admin.py
@@ -1,4 +1,4 @@
-from utils import Session, get_student_id, permission_test
+from tests.utils import Session, get_student_id, permission_test
 
 
 def test_autograde_admin():

--- a/api/tests/test_config_super.py
+++ b/api/tests/test_config_super.py
@@ -1,4 +1,4 @@
-from utils import permission_test
+from tests.utils import permission_test
 
 sample_config = [{"key": "MAX_IDES", "value": "75"}]
 

--- a/api/tests/test_courses_admin.py
+++ b/api/tests/test_courses_admin.py
@@ -1,4 +1,4 @@
-from utils import Session, permission_test
+from tests.utils import Session, permission_test
 
 
 def test_courses_admin():

--- a/api/tests/test_courses_public.py
+++ b/api/tests/test_courses_public.py
@@ -1,4 +1,4 @@
-from utils import Session
+from tests.utils import Session
 
 
 def test_courses_public():

--- a/api/tests/test_dangling_admin.py
+++ b/api/tests/test_dangling_admin.py
@@ -1,4 +1,4 @@
-from utils import permission_test
+from tests.utils import permission_test
 
 
 def test_dangling_admin():

--- a/api/tests/test_ide_admin.py
+++ b/api/tests/test_ide_admin.py
@@ -1,4 +1,4 @@
-from utils import permission_test
+from tests.utils import permission_test
 
 settings_sample = {
     "network_locked": False,

--- a/api/tests/test_ide_public.py
+++ b/api/tests/test_ide_public.py
@@ -1,4 +1,4 @@
-from utils import Session, create_repo
+from tests.utils import Session, create_repo
 
 
 def test_ide_public():

--- a/api/tests/test_lectures_admin.py
+++ b/api/tests/test_lectures_admin.py
@@ -1,7 +1,8 @@
 import io
 
 import requests
-from utils import Session
+
+from tests.utils import Session
 
 
 def test_lectures_admin():

--- a/api/tests/test_lectures_public.py
+++ b/api/tests/test_lectures_public.py
@@ -1,7 +1,8 @@
 import io
 
 import requests
-from utils import Session
+
+from tests.utils import Session
 
 
 def test_lectures_public():

--- a/api/tests/test_profile_public.py
+++ b/api/tests/test_profile_public.py
@@ -1,6 +1,5 @@
-from utils import Session
-
 from anubis.utils.data import rand
+from tests.utils import Session
 
 
 def test_profile_public():

--- a/api/tests/test_questions_admin.py
+++ b/api/tests/test_questions_admin.py
@@ -1,4 +1,4 @@
-from utils import Session, permission_test
+from tests.utils import Session, permission_test
 
 sample_question = {
     "question": "question",

--- a/api/tests/test_questions_public.py
+++ b/api/tests/test_questions_public.py
@@ -1,4 +1,4 @@
-from utils import Session
+from tests.utils import Session
 
 
 def test_questions_public():

--- a/api/tests/test_regrade_admin.py
+++ b/api/tests/test_regrade_admin.py
@@ -1,6 +1,5 @@
-from utils import Session, permission_test, with_context
-
 from anubis.models import Submission
+from tests.utils import Session, permission_test, with_context
 
 
 @with_context

--- a/api/tests/test_repos_public.py
+++ b/api/tests/test_repos_public.py
@@ -1,4 +1,4 @@
-from utils import Session, create_repo
+from tests.utils import Session, create_repo
 
 
 def test_repos_public():

--- a/api/tests/test_static_admin.py
+++ b/api/tests/test_static_admin.py
@@ -1,7 +1,8 @@
 import io
 
 import requests
-from utils import Session
+
+from tests.utils import Session
 
 
 def test_static_admin():

--- a/api/tests/test_static_public.py
+++ b/api/tests/test_static_public.py
@@ -1,7 +1,8 @@
 import io
 
 import requests
-from utils import Session
+
+from tests.utils import Session
 
 
 def test_static_public():

--- a/api/tests/test_students_admin.py
+++ b/api/tests/test_students_admin.py
@@ -1,4 +1,4 @@
-from utils import Session, permission_test
+from tests.utils import Session, permission_test
 
 
 def test_students_admin():

--- a/api/tests/test_visuals_admin.py
+++ b/api/tests/test_visuals_admin.py
@@ -1,4 +1,4 @@
-from utils import Session, permission_test
+from tests.utils import Session, permission_test
 
 
 def test_visuals_admin():

--- a/api/tests/test_visuals_public.py
+++ b/api/tests/test_visuals_public.py
@@ -1,4 +1,4 @@
-from utils import Session
+from tests.utils import Session
 
 
 def test_visuals_public():

--- a/api/tests/utils.py
+++ b/api/tests/utils.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 import traceback
+from typing import Any, Callable, List
 
 import requests
 
@@ -158,7 +159,7 @@ class Session(object):
         port: int = 5000,
     ):
         self.url = f"http://{domain}:{port}"
-        self.timings = []
+        self.timings: List[Any] = []
         self._session, self.netid = _create_user_session(self.url, permission, new=new, add_to_os=add_to_os)
 
     @staticmethod
@@ -322,7 +323,13 @@ def get_student_id():
     return student.id
 
 
-def permission_test(path, fail_for: list = None, method="get", after: callable = None, **kwargs):
+def permission_test(
+    path,
+    fail_for: list = None,
+    method="get",
+    after: Callable[..., Any] = None,
+    **kwargs,
+):
     def _test_permission(_path, _fail_for, _method, _after, **_kwargs):
         sessions = {
             "student": Session("student"),

--- a/docs/README.md
+++ b/docs/README.md
@@ -237,8 +237,8 @@ functions. Here is a minimal example of an assignment.py that will build
 and run a single simple test.
 
 ``` python
-from utils import register_test, register_build, exec_as_student
-from utils import (
+from tests.utils import register_test, register_build, exec_as_student
+from tests.utils import (
     TestResult, BuildResult, Panic, DEBUG,
     xv6_run, did_xv6_crash,
     verify_expected, search_lines, test_lines

--- a/docs/design-tex/autograding.tex
+++ b/docs/design-tex/autograding.tex
@@ -88,8 +88,8 @@ through hooking functions.
 Here is a minimal example of an assignment.py that will build and run a single simple test.
 
 \begin{minted}{python}
-from utils import register_test, register_build, exec_as_student
-from utils import (
+from tests.utils import register_test, register_build, exec_as_student
+from tests.utils import (
     TestResult, BuildResult, Panic, DEBUG,
     xv6_run, did_xv6_crash,
     verify_expected, search_lines, test_lines

--- a/docs/old-anubis-design.md
+++ b/docs/old-anubis-design.md
@@ -735,8 +735,8 @@ test code. Just like all the other cool libraries out there, the anubis pipeline
 functions. Here is a minimal example of an assignment.py that will build and run a single simple test.
 
 ```python
-from utils import register_test, register_build, exec_as_student
-from utils import (
+from tests.utils import register_test, register_build, exec_as_student
+from tests.utils import (
     TestResult, BuildResult, Panic, DEBUG, 
     xv6_run, did_xv6_crash, 
     verify_expected, search_lines, test_lines

--- a/theia/ide/theia-admin/cli/anubis/cli.py
+++ b/theia/ide/theia-admin/cli/anubis/cli.py
@@ -158,7 +158,7 @@ def sync():
     # click.echo(json.dumps(assignment_meta, indent=2))
     try:
         import assignment
-        import utils
+        import tests.utils
     except ImportError:
         click.echo('Not in an assignment directory')
         return 1


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#pull-requests

Commit message formatting guidelines:
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Include with development environment you are using.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR contains mostly changes involved in changing the type annotations, refactoring functions, and adding dependencies, but not actual feature changes with some exceptions. The changes are mainly for fixing the typing errors discovered by running mypy on python files in `/api`. The commits are ordered in a sense that the changes shift from CI passing state to CI passing state.

In the future, we can add other linters like `pyflakes`, `black`, and `isort` to the CI for better code quality control.

Some other things to note with this PR:
1. I omitted changes related to adding typing support for `flask_sqlalchemy` as it will be kind of convoluted and require some changes in an upstream library that I'm planning to add.
2. I skipped some other changes related to Python 3.9+ features (and 3.10+ in the future). One possibility will be shifting to `dict[]` and `list[]` generics since their generic correspondents in `typing` are being [deprecated](https://www.python.org/dev/peps/pep-0585/#implementation).
3. With requirements organized with `.in` files, we can better separate the requirements for development and production. We will need to recompile the `.txt` files by running `make requirements` whenever the `.in` files are updated.
4. Mypy and the type annotations are not expected to change our backend in runtime.
5. It can be challenging to type check attributes patched by `backref` using to the models.

