### PR TITLE
FIX correctly set the author of the embed content

### DIFF
--- a/api/jobs/bot.py
+++ b/api/jobs/bot.py
@@ -192,9 +192,8 @@ def generate_ide_report(day=None) -> discord.Embed:
 
     return discord.Embed(
         title='IDE report',
-        author='Anubis Bot',
         description="```" + report + "```"
-    ).set_thumbnail(url=bot.user.avatar_url)
+    ).set_thumbnail(url=bot.user.avatar_url).set_author(name="Anubis Bot")
 
 
 bot = commands.Bot(


### PR DESCRIPTION
Because the constructor uses `**kwargs`, no run-time error was raised. This is found with mypy using the stubs for discord.py.

[See also](https://github.com/Rapptz/discord.py/blob/9a61a5a0630f54a2365a11c110890c6952c88380/discord/embeds.py#L177-L187)

<!--
Before submitting a pull request, please read
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#pull-requests

Commit message formatting guidelines:
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Include with development environment you are using.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
