### PR TITLE
FIX container overflow for long contents

### DIFF
--- a/web/src/Pages/Public/Submission/Submission.styles.jsx
+++ b/web/src/Pages/Public/Submission/Submission.styles.jsx
@@ -43,7 +43,7 @@ export const useStyles = makeStyles((theme) => ({
     position: 'absolute',
     display: 'flex',
     justifyContent: 'center',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     width: '100%',
     height: '100%',
   },


### PR DESCRIPTION
Before (note that we have scrolled to the top already):
![image](https://user-images.githubusercontent.com/39874143/147844895-b4b9d16e-8e9a-43bb-8294-aba6bec2ab71.png)


After:
![image](https://user-images.githubusercontent.com/39874143/147844891-a9489ab9-9731-433f-b1b0-f86616fc6b5b.png)
