### PR TITLE
ADD Generate Test Coverage Report for the API server

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -5,3 +5,4 @@ __pycache__
 .idea
 tests
 .data
+.coverage

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -3,5 +3,6 @@ venv
 env
 .env
 .data
+.coverage
 
 .pytest_cache

--- a/api/Makefile
+++ b/api/Makefile
@@ -30,6 +30,11 @@ venv:
 test: venv
 	./tests/test.sh
 
+.PHONY: coverage
+coverage:					# Run tests and generate a coverage report
+	env COVERAGE=1 ./tests/test.sh
+	./venv/bin/coverage report -m
+
 .PHONY: migrations          # Run alembic migrations
 migrations: venv
 	./venv/bin/alembic upgrade head

--- a/api/requirements/dev.in
+++ b/api/requirements/dev.in
@@ -11,3 +11,4 @@ pip-tools
 
 # Python testing framework
 pytest
+coverage

--- a/api/requirements/dev.txt
+++ b/api/requirements/dev.txt
@@ -55,6 +55,8 @@ click==7.1.2
     #   flask
     #   pip-tools
     #   rq
+coverage==6.2
+    # via -r requirements/dev.in
 cryptography==35.0.0
     # via -r requirements/common.txt
 cycler==0.11.0

--- a/api/tests/test.sh
+++ b/api/tests/test.sh
@@ -6,6 +6,7 @@ cd $(dirname $0)
 
 TEST_ROOT="$(pwd)"
 API_ROOT="$(pwd)/.."
+SOURCE_DIRS="${API_ROOT}/anubis,${API_ROOT}/jobs"
 
 pushd ..
 make venv
@@ -20,5 +21,11 @@ if (( $# == 0 )); then
     python seed.py 1>/dev/null
 fi
 
-echo 'Running tests...'
-exec pytest -p no:warnings $@
+if (( COVERAGE == 1 )); then
+    echo 'Running tests with coverage...'
+    coverage run --source=${SOURCE_DIRS} -m pytest -p no:warnings $@
+    mv ${TEST_ROOT}/.coverage ${API_ROOT}
+else
+    echo 'Running tests...'
+    exec pytest -p no:warnings $@
+fi


### PR DESCRIPTION
This allows us to run `tests/test.sh` to generate a test coverage report using [coverage.py](https://coverage.readthedocs.io/en/6.2/index.html) with pytest.

The report can be generated with `make coverage` under `api`.

An example of the report:
```
Name                                        Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------
anubis/__init__.py                              0      0   100%
anubis/app.py                                  32     28    12%   11-22, 34-52, 64-77
anubis/views/super/__init__.py                  7      7     0%   1-13
anubis/views/super/config.py                   29     29     0%   1-73
anubis/views/super/ide.py                      64     64     0%   1-114
anubis/views/super/playgrounds.py              37     37     0%   1-88

......

jobs/autograde_recalculate.py                  21     21     0%   1-60
jobs/bot.py                                   106    106     0%   1-307
jobs/daily_cleanup.py                          36     36     0%   1-112
jobs/poller.py                                 16     16     0%   1-40
jobs/reaper.py                                 55     55     0%   1-167
jobs/reporter.py                                7      7     0%   1-15
jobs/visuals.py                                17     17     0%   1-34
-------------------------------------------------------------------------
TOTAL                                        5073   4503    11%
```