### PR TITLE
FIX diff to generate the correct context for short inputs and append newlines to the output

### DIFF
--- a/theia/ide/theia-base/cli/anubis/assignment/utils.py
+++ b/theia/ide/theia-base/cli/anubis/assignment/utils.py
@@ -291,19 +291,26 @@ def test_lines(
     # unzip the context as tuples
     expected_context, stdout_context = zip(*context)
 
+    # We fill the context with the leading part of the lines that
+    # only present in the longer list of lines
+    # if there IS a mismatch (i.e. mismatch_index != -1 or len(expected_lines) != len(stdout_lines))
+    start = min(len(expected_lines), len(stdout_lines))
+
     if mismatch_index == -1:
         if len(expected_lines) == len(stdout_lines):
             return True, []
 
-        # When there is no mismatch and the length of the lines are different,
-        # we fill the context with the leading part of the lines that
-        # only present in the longer list of lines
-        start = min(len(expected_lines), len(stdout_lines))
+        # If no mismatch occurs, we fill the entire trailing part of
+        # the longer list into the context 
         end = start + context_length
-        if len(expected_lines) > len(stdout_lines):
-            expected_context += preprocess_func(*expected_lines[start:end])
-        else:
-            stdout_context += preprocess_func(*stdout_lines[start:end])
+    else:
+        # Otherwise, we only fill the context to the desired size 
+        end = start + (context_length - len(context))
+
+    if len(expected_lines) > len(stdout_lines):
+        expected_context += preprocess_func(*expected_lines[start:end])
+    else:
+        stdout_context += preprocess_func(*stdout_lines[start:end])
 
     return False, list(difflib.unified_diff(expected_context, stdout_context, lineterm=""))
 

--- a/theia/ide/theia-base/cli/anubis/assignment/utils.py
+++ b/theia/ide/theia-base/cli/anubis/assignment/utils.py
@@ -247,9 +247,9 @@ def test_lines(
 
     >>> test_lines(['a', 'b', 'c'], ['a', 'b', 'c']) -> (True, [])
     >>> test_lines(['a', 'debugging', 'b', 'c'], ['a', 'b', 'c'])
-    # -> (False, ['--- \n', '+++ \n', '@@ -1,3 +1,4 @@\n', ' a', '+debugging', ' b', ' c'])
+    # -> (False, ['--- ', '+++ ', '@@ -1,3 +1,4 @@', ' a', '+debugging', ' b', ' c'])
     >>> test_lines(['a', 'b'],      ['a', 'b', 'c'])
-    # -> (False, ['--- \n', '+++ \n', '@@ -1,3 +1,2 @@\n', ' a', ' b', '-c'])
+    # -> (False, ['--- ', '+++ ', '@@ -1,3 +1,2 @@', ' a', ' b', '-c'])
 
     :param stdout_lines: students standard out lines as a list of strings
     :param expected_lines: expected lines as a list of strings
@@ -305,7 +305,7 @@ def test_lines(
         else:
             stdout_context += preprocess_func(*stdout_lines[start:end])
 
-    return False, list(difflib.unified_diff(expected_context, stdout_context))
+    return False, list(difflib.unified_diff(expected_context, stdout_context, lineterm=""))
 
 
 def verify_expected(
@@ -337,7 +337,7 @@ def verify_expected(
     if not passed:
         if diff:
             test_result.output_type = 'diff'
-            test_result.output = ''.join(diff)
+            test_result.output = '\n'.join(diff)
         else:
             # If diff is not available, fall back to the old way of displaying outputs
             test_result.output_type = 'text'

--- a/theia/ide/theia-base/cli/anubis/assignment/utils.py
+++ b/theia/ide/theia-base/cli/anubis/assignment/utils.py
@@ -289,7 +289,7 @@ def test_lines(
             mismatch_index = index
 
     # unzip the context as tuples
-    expected_context, stdout_context = zip(*context)
+    expected_context, stdout_context = zip(*context) if len(context) > 0 else (tuple(), tuple())
 
     # We fill the context with the leading part of the lines that
     # only present in the longer list of lines

--- a/theia/ide/theia-base/cli/tests/test_utils.py
+++ b/theia/ide/theia-base/cli/tests/test_utils.py
@@ -76,6 +76,24 @@ def compare_test_fixtures() -> List[CompareTestFixture]:
         actual=["a", "b"],
         expected=["a", "b", "c"],
         diff=['--- ', '+++ ', '@@ -1,3 +1,2 @@', " a", " b", "-c"],
+    ), CompareTestFixture(
+        comp_func=utils.test_lines,
+        matched=False,
+        actual=["exec test failed"],
+        expected=["sample 1", "sample 2", "sample 3", "sample 4", "sample 5", "sample 6", "sample 7"],
+        diff=["--- ", "+++ ", "@@ -1,5 +1 @@", "-sample 1", "-sample 2", "-sample 3", "-sample 4", "-sample 5", "+exec test failed"]
+    ), CompareTestFixture(
+        comp_func=utils.test_lines,
+        matched=False,
+        actual=["sample 1", "sample 2", "exec test failed"],
+        expected=["sample 1", "sample 2", "sample 3", "sample 4", "sample 5", "sample 6", "sample 7"],
+        diff=["--- ", "+++ ", "@@ -1,5 +1,3 @@", " sample 1", " sample 2", "-sample 3", "-sample 4", "-sample 5", "+exec test failed"]
+    ), CompareTestFixture(
+        comp_func=utils.test_lines,
+        matched=False,
+        actual=["sample 1", "sample 2", "sample 3", "sample 4", "sample 5", "sample 6", "sample 7"],
+        expected=["sample 1", "sample 2", "sample x"],
+        diff=["--- ", "+++ ", "@@ -1,3 +1,5 @@", " sample 1", " sample 2", "-sample x", "+sample 3", "+sample 4", "+sample 5"]
     )]
 
 def test_compare_func(compare_test_fixtures: List[CompareTestFixture]):

--- a/theia/ide/theia-base/cli/tests/test_utils.py
+++ b/theia/ide/theia-base/cli/tests/test_utils.py
@@ -26,7 +26,7 @@ def compare_test_fixtures() -> List[CompareTestFixture]:
         matched=False,
         actual=["asdf", "qwe", "123"],
         expected=["asd", "qwe", "123"],
-        diff=['--- \n', '+++ \n', '@@ -1,3 +1,3 @@\n', '-asd', '+asdf', ' qwe', ' 123'],
+        diff=['--- ', '+++ ', '@@ -1,3 +1,3 @@', '-asd', '+asdf', ' qwe', ' 123'],
     ), CompareTestFixture(
         comp_func=utils.test_lines,
         matched=True,
@@ -38,7 +38,7 @@ def compare_test_fixtures() -> List[CompareTestFixture]:
         matched=False,
         actual=["AsD", "QwEd", "123"],
         expected=["aSd", "qWee", "123"],
-        diff=['--- \n', '+++ \n', '@@ -1,3 +1,3 @@\n', " asd", "-qwee", "+qwed", " 123"],
+        diff=['--- ', '+++ ', '@@ -1,3 +1,3 @@', " asd", "-qwee", "+qwed", " 123"],
         case_sensitive=False,
     ), CompareTestFixture(
         comp_func=utils.search_lines,
@@ -56,26 +56,26 @@ def compare_test_fixtures() -> List[CompareTestFixture]:
         matched=False,
         actual=["asd", "qww"],
         expected=["asd", "qww", "123A"],
-        diff=['--- \n', '+++ \n', '@@ -1,3 +1,2 @@\n', " asd", " qww", "-123A"],
+        diff=['--- ', '+++ ', '@@ -1,3 +1,2 @@', " asd", " qww", "-123A"],
     ), CompareTestFixture(
         comp_func=utils.test_lines,
         matched=False,
         actual=["asd", "qww"],
         expected=["asd", "qww", "123A"],
-        diff=['--- \n', '+++ \n', '@@ -1,3 +1,2 @@\n', " asd", " qww", "-123a"],
+        diff=['--- ', '+++ ', '@@ -1,3 +1,2 @@', " asd", " qww", "-123a"],
         case_sensitive=False,
     ), CompareTestFixture(
         comp_func=utils.test_lines,
         matched=False,
         actual=["asd", "qww", "fgff", "kasd", "asdasd"],
         expected=["asd", "qww", "fgff", "kasd", "asdasd", "123A"],
-        diff=['--- \n', '+++ \n', '@@ -3,4 +3,3 @@\n', " fgff", " kasd", " asdasd", "-123A"],
+        diff=['--- ', '+++ ', '@@ -3,4 +3,3 @@', " fgff", " kasd", " asdasd", "-123A"],
     ), CompareTestFixture(
         comp_func=utils.test_lines,
         matched=False,
         actual=["a", "b"],
         expected=["a", "b", "c"],
-        diff=['--- \n', '+++ \n', '@@ -1,3 +1,2 @@\n', " a", " b", " -c"],
+        diff=['--- ', '+++ ', '@@ -1,3 +1,2 @@', " a", " b", "-c"],
     )]
 
 def test_compare_func(compare_test_fixtures: List[CompareTestFixture]):

--- a/theia/ide/theia-base/cli/tests/test_utils.py
+++ b/theia/ide/theia-base/cli/tests/test_utils.py
@@ -94,6 +94,18 @@ def compare_test_fixtures() -> List[CompareTestFixture]:
         actual=["sample 1", "sample 2", "sample 3", "sample 4", "sample 5", "sample 6", "sample 7"],
         expected=["sample 1", "sample 2", "sample x"],
         diff=["--- ", "+++ ", "@@ -1,3 +1,5 @@", " sample 1", " sample 2", "-sample x", "+sample 3", "+sample 4", "+sample 5"]
+    ), CompareTestFixture(
+        comp_func=utils.test_lines,
+        matched=True,
+        actual=["asd\n"],
+        expected=["asd"],
+        diff=[]
+    ), CompareTestFixture(
+        comp_func=utils.test_lines,
+        matched=False,
+        actual=[],
+        expected=["bar"],
+        diff=["--- ", "+++ ", "@@ -1 +0,0 @@", "-bar"]
     )]
 
 def test_compare_func(compare_test_fixtures: List[CompareTestFixture]):

--- a/web/src/components/core/SubmissionTestExpanded/SubmissionTestExpanded.jsx
+++ b/web/src/components/core/SubmissionTestExpanded/SubmissionTestExpanded.jsx
@@ -105,7 +105,7 @@ export default function SubmissionTestExpanded({
         )}
         {testOutputType === 'diff' && (
           <React.Fragment>
-            <h2>Actual / Expected Output</h2>
+            <h2>Expected / Actual Output</h2>
             <Box className={classes.diffBox}>
               {diffs && diffs.map((diff, index) => renderDiffs({...diff, tokens: tokens[index]}))}
             </Box>

--- a/web/src/components/core/SubmissionTestExpanded/SubmissionTestExpanded.jsx
+++ b/web/src/components/core/SubmissionTestExpanded/SubmissionTestExpanded.jsx
@@ -44,7 +44,6 @@ export default function SubmissionTestExpanded({
   const classes = useStyles();
   const diffs = useMemo(() => {
     if (!testOutput) return [];
-    console.log(testOutput);
     return parseDiff(testOutput ?? '', {nearbySequences: 'zip'});
   }, [testOutput]);
   const tokens = useMemo(() => {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#pull-requests

Commit message formatting guidelines:
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Include with development environment you are using.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
This fixes the following bugs:

- When a mismatch occurs and one input is shorter than another, the remaining lines in the longer input will be discarded while the context might not have reached the desired number of lines (having 1 line instead of 5 for example).
- Newlines are not added to the output generated.
- Fix the confusion between the expected and actual output (the tooltip showed Actual / Expected while the expected output appears in the left)

It also removes an unused log message.