### PR TITLE
CHG use longer context for the diff produced

### DIFF
--- a/.github/workflows/test-autograde-cli.yml
+++ b/.github/workflows/test-autograde-cli.yml
@@ -1,0 +1,35 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Anubis Autograde CLI Test
+
+defaults:
+  run:
+    shell: bash
+    working-directory: theia/ide/theia-base/cli
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        set -ex
+        python -m venv venv
+        ./venv/bin/pip install -r requirements.txt
+    - name: Test with pytest
+      run: |
+        ./venv/bin/pytest -vvv

--- a/api/anubis/utils/testing/diffs.py
+++ b/api/anubis/utils/testing/diffs.py
@@ -1,0 +1,23 @@
+import difflib
+import string
+import random
+from typing import Callable, Iterable, TypeVar
+
+T = TypeVar("T")
+
+def rand_swap(collection: Iterable[T], swap_probability: float, generator_func: Callable[[T], T]) -> Iterable[T]:
+    return [generator_func(item) if random.random() < swap_probability else item for item in collection]
+
+rand_text = lambda: "".join(random.choices(string.ascii_letters, k=random.randint(10, 50)))
+rand_lines = lambda n: [rand_text() for _ in range(n)]
+swap_text = lambda text: "".join(rand_swap(text, 0.1, lambda _: random.choice(string.ascii_letters)))
+swap_lines = lambda lines: rand_swap(lines, 0.1, swap_text)
+
+diffs = []
+
+for i in range(10):
+    expected_output = rand_lines(i * 100) 
+    actual_output = swap_lines(expected_output) + rand_lines(5)
+    diffs.append("\n".join(difflib.unified_diff(expected_output, actual_output, lineterm="")))
+
+rand_diff = lambda: random.choice(diffs)

--- a/api/anubis/utils/testing/seed.py
+++ b/api/anubis/utils/testing/seed.py
@@ -34,6 +34,7 @@ from anubis.models import (
 from anubis.utils.data import rand
 from anubis.utils.data import with_context
 from anubis.utils.testing.db import clear_database
+from anubis.utils.testing.diffs import rand_diff
 from anubis.utils.testing.lorem import lorem
 from anubis.utils.testing.names import names
 from anubis.utils.logging import logger
@@ -253,7 +254,7 @@ def init_submissions(submissions):
                 else:
                     test_result.message = "Test failed"
                     test_result.output_type = "diff"
-                    test_result.output = "--- \n+++ \n@@ -1,3 +1,3 @@\n a\n-c\n+b\n d"
+                    test_result.output = rand_diff()
 
 
 def init_forums(course: Course):

--- a/theia/ide/theia-base/cli/anubis/assignment/utils.py
+++ b/theia/ide/theia-base/cli/anubis/assignment/utils.py
@@ -238,7 +238,7 @@ def test_lines(
     stdout_lines: typing.List[str],
     expected_lines: typing.List[str],
     case_sensitive: bool = True,
-    context_length: int = 5,
+    context_length: int = 1000,
 ) -> CompareFuncReturnT:
     """
     Test lines for exact equality. Whitespace will be stripped off each line automatically.

--- a/theia/ide/theia-base/cli/anubis/assignment/utils.py
+++ b/theia/ide/theia-base/cli/anubis/assignment/utils.py
@@ -264,15 +264,10 @@ def test_lines(
     # The remaining offset until the first occurence of mismatch is centralized
     # within the context
     context_remaining_offset = context_length // 2
-    # A general preprocessor function for text
-    if case_sensitive:
-        preprocess_func = lambda *texts: tuple(text.strip() for text in texts)
-    else:
-        preprocess_func = lambda *texts: tuple(text.strip().lower() for text in texts)
 
     for index, (_a, _b) in enumerate(zip(expected_lines, stdout_lines)):
         # We defer text preprocessing until we need the lines
-        _a, _b = preprocess_func(_a, _b)
+        _a, _b = (_a.strip(), _b.strip()) if case_sensitive else (_a.strip().lower(), _b.strip().lower())
         context.append((_a, _b))
 
         # When there is a mismatch already, we are only motivated to fill up
@@ -306,6 +301,12 @@ def test_lines(
     else:
         # Otherwise, we only fill the context to the desired size 
         end = start + (context_length - len(context))
+
+    # A general preprocessor function for text
+    if case_sensitive:
+        preprocess_func = lambda *texts: tuple(text.strip() for text in texts)
+    else:
+        preprocess_func = lambda *texts: tuple(text.strip().lower() for text in texts)
 
     if len(expected_lines) > len(stdout_lines):
         expected_context += preprocess_func(*expected_lines[start:end])

--- a/theia/ide/theia-base/cli/requirements.txt
+++ b/theia/ide/theia-base/cli/requirements.txt
@@ -1,3 +1,4 @@
 Click>=7.0
 requests
 pyyaml
+pytest

--- a/theia/ide/theia-base/cli/tests/test_utils.py
+++ b/theia/ide/theia-base/cli/tests/test_utils.py
@@ -81,19 +81,19 @@ def compare_test_fixtures() -> List[CompareTestFixture]:
         matched=False,
         actual=["exec test failed"],
         expected=["sample 1", "sample 2", "sample 3", "sample 4", "sample 5", "sample 6", "sample 7"],
-        diff=["--- ", "+++ ", "@@ -1,5 +1 @@", "-sample 1", "-sample 2", "-sample 3", "-sample 4", "-sample 5", "+exec test failed"]
+        diff=["--- ", "+++ ", "@@ -1,7 +1 @@", "-sample 1", "-sample 2", "-sample 3", "-sample 4", "-sample 5", "-sample 6", "-sample 7", "+exec test failed"]
     ), CompareTestFixture(
         comp_func=utils.test_lines,
         matched=False,
         actual=["sample 1", "sample 2", "exec test failed"],
         expected=["sample 1", "sample 2", "sample 3", "sample 4", "sample 5", "sample 6", "sample 7"],
-        diff=["--- ", "+++ ", "@@ -1,5 +1,3 @@", " sample 1", " sample 2", "-sample 3", "-sample 4", "-sample 5", "+exec test failed"]
+        diff=["--- ", "+++ ", "@@ -1,7 +1,3 @@", " sample 1", " sample 2", "-sample 3", "-sample 4", "-sample 5", "-sample 6", "-sample 7", "+exec test failed"]
     ), CompareTestFixture(
         comp_func=utils.test_lines,
         matched=False,
         actual=["sample 1", "sample 2", "sample 3", "sample 4", "sample 5", "sample 6", "sample 7"],
         expected=["sample 1", "sample 2", "sample x"],
-        diff=["--- ", "+++ ", "@@ -1,3 +1,5 @@", " sample 1", " sample 2", "-sample x", "+sample 3", "+sample 4", "+sample 5"]
+        diff=["--- ", "+++ ", "@@ -1,3 +1,7 @@", " sample 1", " sample 2", "-sample x", "+sample 3", "+sample 4", "+sample 5", "+sample 6", "+sample 7"]
     ), CompareTestFixture(
         comp_func=utils.test_lines,
         matched=True,
@@ -106,6 +106,15 @@ def compare_test_fixtures() -> List[CompareTestFixture]:
         actual=[],
         expected=["bar"],
         diff=["--- ", "+++ ", "@@ -1 +0,0 @@", "-bar"]
+    ), CompareTestFixture(
+        comp_func=utils.test_lines,
+        matched=False,
+        actual=["my broken for loop" for _ in range(2000)],
+        expected=["foo", "bar"],
+        # 1000 is the default cutoff for the length of the context
+        # We make sure that excessively long output produced by
+        # student code will not go into the difflib.unified_diff function
+        diff=["--- ", "+++ ", "@@ -1,2 +1,1000 @@", "-foo", "-bar"] + ["+my broken for loop" for _ in range(1000)]
     )]
 
 def test_compare_func(compare_test_fixtures: List[CompareTestFixture]):


### PR DESCRIPTION
- Increases the default context length (so the students can see a fuller diff in most cases)
- Avoid using a wrapper function in the loop for better performance