### PR TITLE
CHG Make Health Check slightly more verbose

### DIFF
--- a/api/anubis/utils/healthcheck.py
+++ b/api/anubis/utils/healthcheck.py
@@ -1,3 +1,4 @@
+import traceback
 from flask import Flask
 
 
@@ -5,6 +6,7 @@ def add_healthcheck(app: Flask):
     from anubis.utils.http.decorators import json_response
     from anubis.models import Config
     from anubis.utils.cache import cache_health
+    from anubis.utils.logging import logger
     from anubis.env import env
 
     @app.route("/")
@@ -41,22 +43,22 @@ def add_healthcheck(app: Flask):
             Config.query.all()
 
         # If there is any issue, mark the db
-        # connection as Unhealthy
+        # connection as Unhealthy and log the error
         except Exception as e:
             status["db"] = "Unhealthy"
             status_code = 500
-            print(e)
+            logger.error(traceback.format_exc())
 
         # Attempt to connect to cache
         try:
             cache_health()
 
         # If there is any issue, mark the cache
-        # connection as Unhealthy
+        # connection as Unhealthy and log the error
         except Exception as e:
             status["cache"] = "Unhealthy"
             status_code = 500
-            print(e)
+            logger.error(traceback.format_exc())
 
         # Pass back status and status_code
         return status, status_code

--- a/api/anubis/utils/healthcheck.py
+++ b/api/anubis/utils/healthcheck.py
@@ -42,9 +42,10 @@ def add_healthcheck(app: Flask):
 
         # If there is any issue, mark the db
         # connection as Unhealthy
-        except:
+        except Exception as e:
             status["db"] = "Unhealthy"
             status_code = 500
+            print(e)
 
         # Attempt to connect to cache
         try:
@@ -52,9 +53,10 @@ def add_healthcheck(app: Flask):
 
         # If there is any issue, mark the cache
         # connection as Unhealthy
-        except:
+        except Exception as e:
             status["cache"] = "Unhealthy"
             status_code = 500
+            print(e)
 
         # Pass back status and status_code
         return status, status_code


### PR DESCRIPTION
Currently, the health check doesn't provide much information if any of the components is "unhealthy". I added some print statements to at least show the error messages.

This is just a temporary solution before we introduce more complicated health check mechanisms.