### PR TITLE
ADD visible_to_students field in Course.jsx, FIX tooltip feature for assignments that are visible to students

### DIFF
--- a/web/src/components/core/AssignmentItem/AssignmentItem.jsx
+++ b/web/src/components/core/AssignmentItem/AssignmentItem.jsx
@@ -25,7 +25,7 @@ const AssignmentItem = ({
       showStatus={false}
       title={name}
       subTitle={`from: ${course.name}`}
-      titleIcon={visible_to_students ? <AssignmentOutlinedIcon/> :
+      titleIcon={visible_to_students ? <Tooltip title={'Visible to students.'}><AssignmentOutlinedIcon/></Tooltip> :
         <Tooltip title={'Not visible to students.'}><VisibilityOff className={classes.red}/></Tooltip>}
       link={`/courses/assignment?assignmentId=${id}`}
     >

--- a/web/src/pages/core/public/Course/Course.jsx
+++ b/web/src/pages/core/public/Course/Course.jsx
@@ -92,6 +92,7 @@ const Course = () => {
                 id={assignment.id}
                 course={assignment.course}
                 submitted={assignment.has_submission}
+                visible_to_students={assignment.visible_to_students}
               />
             ))}
           </Box>


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#pull-requests

Commit message formatting guidelines:
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Include with development environment you are using.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

A visible_to_students variable was added to Course.jsx to ensure that the visibility shows up correctly under an AssignmentItem component. A tooltip was added for visible assignments under AssignmentItem.jsx
![image](https://user-images.githubusercontent.com/53961253/160307079-e27a2545-5f94-4584-89e8-4f8365db73a8.png)

