### PR TITLE
FIX disable warning msg on iPadOS browser

### DIFF
--- a/web/src/components/shared/DeviceWarning.jsx
+++ b/web/src/components/shared/DeviceWarning.jsx
@@ -1,25 +1,22 @@
 import React from 'react';
-import {browserName, isBrowser, isChrome, isFirefox} from 'react-device-detect';
+import {browserName, isChrome, isDesktop, isFirefox, isTablet} from 'react-device-detect';
 import {useSnackbar} from 'notistack';
 
 export default function DeviceWarning() {
   const {enqueueSnackbar} = useSnackbar();
 
   React.useEffect(() => {
-    if ((isChrome || isFirefox) && isBrowser) {
-      return;
-    }
-
-    if (!(isChrome || isFirefox)) {
+    const acceptDevice = isDesktop || isTablet;
+    const acceptBrowser = isChrome || isFirefox;
+    if (!acceptBrowser) {
       enqueueSnackbar(`We noticed you are on ${browserName}. ` +
         'Some things may not work as intended. ' +
         'Try Firefox or Chrome if you run into any issues!', {variant: 'warning'});
       return;
     }
-
-    if (!isBrowser) {
+    if (!acceptDevice) {
       enqueueSnackbar('The Anubis website may not work well ' +
-        'outside of a desktop browser!', {variant: 'warning'});
+        'outside of a desktop or tablet browser!', {variant: 'warning'});
     }
   }, []);
 


### PR DESCRIPTION
Solves #285.

The device warning shown for the iPadOS browser is disabled, by detecting the device with the flag `isTablet` using package `react-device-detect`.

Notice a change from `isBrowser` to `isDesktop`, in which the latter is preferred over `isBrowser` ([source](https://github.com/duskload/react-device-detect/blob/ec3cdbfd410f1e8dd7272fb2f131eb8bdec43ec2/docs/selectors.md))
 