### PR TITLE
ADD sidecar API support to (force) push changes without committing.

### DIFF
--- a/theia/sidecar/app.py
+++ b/theia/sidecar/app.py
@@ -33,6 +33,7 @@ def index():
     repo: str = request.form.get('repo', default=None)
     message: str = request.form.get('message', default='Anubis Cloud IDE Autosave').strip()
     push_only: bool = request.form.get('push_only', default='false').lower() == 'true'
+    force_push: bool = request.form.get('force_push', default='false').lower() == 'true'
 
     # Default commit message if empty
     if message == '':
@@ -77,8 +78,11 @@ def index():
             output.append(commit.stdout)
 
         # Push
+        push_args = ['git', '-c', 'core.hooksPath=/dev/null', '-c', 'alias.push=push', 'push', '--no-verify']
+        if force_push:
+            push_args.append('--force')
         push = subprocess.run(
-            ['git', '-c', 'core.hooksPath=/dev/null', '-c', 'alias.push=push', 'push', '--no-verify'],
+            push_args,
             cwd=repo,
             timeout=3,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#pull-requests

Commit message formatting guidelines:
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Include with development environment you are using.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This allows the student to force push or push without generating a commit
via the CLI without using their own credentials. Making `git push` and
`git push -f` available should be sufficient for students to maneuver with
Git on our IDE instances for the purposes of learning VCS.

It's unlikely that we are going to support more arguments without going into the depth
of actually figuring out a way to keep students authenticated and use git directly.

Allowing the students to push via Anubis CLI is only for the convenience
of not requiring them to enter a GitHub token everytime they push or
storing their SSH keys on the server if they decide to use Git in the IDE.

This is manually tested locally by invoking the added API via the CLI.