### PR TITLE
ADD delete button for pvc #407

### DIFF
--- a/api/tests/test_students_super.py
+++ b/api/tests/test_students_super.py
@@ -14,7 +14,4 @@ def test_students_admin():
         f"/super/students/toggle-anubis_developer/{student_id}",
         fail_for=["student", "ta", "professor"],
     )
-    permission_test(
-        f"/super/students/pvc/{student_id}",
-        fail_for=["student", "ta", "professor"],
-    )
+

--- a/api/tests/test_students_super.py
+++ b/api/tests/test_students_super.py
@@ -14,3 +14,7 @@ def test_students_admin():
         f"/super/students/toggle-anubis_developer/{student_id}",
         fail_for=["student", "ta", "professor"],
     )
+    permission_test(
+        f"/super/students/pvc/{student_id}",
+        fail_for=["student", "ta", "professor"],
+    )

--- a/web/src/components/core/Profile/DeletePvc.jsx
+++ b/web/src/components/core/Profile/DeletePvc.jsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 // Generate the actual button and the box, private
-function generateComponent(deleteThePvc, netid = ``) {
+function generateDeletePvcComponent(deleteThePvc, netid = ``) {
   const [confirm, setConfirm] = useState(false);
   const [open, setOpen] = useState(false);
   const {enqueueSnackbar} = useSnackbar();
@@ -136,7 +136,7 @@ export default function DeletePvc() {
     }).catch(standardErrorHandler(enqueueSnackbar));
   };
 
-  return (generateComponent(deleteThePvc));
+  return (generateDeletePvcComponent(deleteThePvc));
 }
 
 export function SuperDeletePvc({id, netid}) {
@@ -146,5 +146,5 @@ export function SuperDeletePvc({id, netid}) {
     }).catch(standardErrorHandler(enqueueSnackbar));
   };
 
-  return (generateComponent(deleteThePvc, netid));
+  return (generateDeletePvcComponent(deleteThePvc, netid));
 }

--- a/web/src/components/core/Profile/DeletePvc.jsx
+++ b/web/src/components/core/Profile/DeletePvc.jsx
@@ -38,18 +38,13 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function DeletePvc() {
+// Generate the actual button and the box, private
+function generateComponent(deleteThePvc, netid = ``) {
   const [confirm, setConfirm] = useState(false);
   const [open, setOpen] = useState(false);
   const {enqueueSnackbar} = useSnackbar();
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
-
-  const deleteThePvc = () => {
-    axios.delete(`/api/public/profile/pvc`).then((response) => {
-      const data = standardStatusHandler(response, enqueueSnackbar);
-    }).catch(standardErrorHandler(enqueueSnackbar));
-  };
 
   const handleOpen = () => {
     setOpen(true);
@@ -70,12 +65,21 @@ export default function DeletePvc() {
           Are you sure you want to continue?
         </DialogTitle>
         <DialogContent>
-          <DialogContentText>
-            You are about to delete your Anubis Cloud IDE volume. This will delete
-            your home directory, and any work that resides there. If you have a IDE
-            open, the delete will occur after your IDE is stopped. This action cannot
-            be undone. Please confirm to continue.
-          </DialogContentText>
+          {netid === `` ? (
+            <DialogContentText>
+              You are about to delete your Anubis Cloud IDE volume. This will delete
+              your home directory, and any work that resides there. If you have a IDE
+              open, the delete will occur after your IDE is stopped. This action cannot
+              be undone. Please confirm to continue.
+            </DialogContentText>
+          ) : (
+            <DialogContentText>
+              You are about to delete the Anubis Cloud IDE volume for user with NET ID: {`${netid}`}. This will delete
+              their home directory, and any work that resides there. If they have a IDE
+              open, the delete will occur after their IDE is stopped. This action cannot
+              be undone. Please confirm to continue.
+            </DialogContentText>
+          )}
           <FormControlLabel
             control={
               <Switch
@@ -123,4 +127,24 @@ export default function DeletePvc() {
       </Box>
     </Box>
   );
+}
+
+export default function DeletePvc() {
+  const deleteThePvc = () => {
+    axios.delete(`/api/public/profile/pvc`).then((response) => {
+      const data = standardStatusHandler(response, enqueueSnackbar);
+    }).catch(standardErrorHandler(enqueueSnackbar));
+  };
+
+  return (generateComponent(deleteThePvc));
+}
+
+export function SuperDeletePvc({id, netid}) {
+  const deleteThePvc = () => {
+    axios.delete(`/api/super/students/pvc/${id}`).then((response) => {
+      const data = standardStatusHandler(response, enqueueSnackbar);
+    }).catch(standardErrorHandler(enqueueSnackbar));
+  };
+
+  return (generateComponent(deleteThePvc, netid));
 }

--- a/web/src/pages/core/super/Users.jsx
+++ b/web/src/pages/core/super/Users.jsx
@@ -18,6 +18,8 @@ import Typography from '@mui/material/Typography';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import ExitToAppIcon from '@mui/icons-material/ExitToApp';
 
+import {SuperDeletePvc} from '../../../components/core/Profile/DeletePvc.jsx';
+
 import standardStatusHandler from '../../../utils/standardStatusHandler';
 import standardErrorHandler from '../../../utils/standardErrorHandler';
 
@@ -130,6 +132,14 @@ const useColumns = (pageState, enqueueSnackbar) => () => ([
       </React.Fragment>
     ),
     width: 150,
+  },
+  {
+    field: 'Delete IDE Volume',
+    headerName: 'Delete IDE Volume',
+    renderCell: (params) => (
+      <SuperDeletePvc id={`${params.row.id}`} netid={`${params.row.netid}`}/>
+    ),
+    width: 200,
   },
 ]);
 


### PR DESCRIPTION
[](url)Ticket is attached under development.

Backend:
Added function for super to enqueue the reap_pvc runner for individual students by id.
A test for super permissions was added.

Frontend:
Under Super -> student page, for each column now there is a button to remove student PVC with a pop-up that confirms it. The confirm message will contain the student's netid. This is implemented by reusing the existing `DeletePvc.jsx` file while adding a variation that would route to the super API with student id as params. 

The already existing profile ->delete PVC functionality (what `DeletePvc.jsx` was originally for) was tested to behave exactly the same as before.

Demo:
![one](https://user-images.githubusercontent.com/56315630/194467491-78c76094-01c5-4f1b-baf3-a64a0cb2964a.PNG)
![two](https://user-images.githubusercontent.com/56315630/194467516-91a27336-2ae4-4e64-b1e4-dffd254e7b17.PNG)

K8s does not run in debug environment, the logs indicate we would delete the correct PVC. 
![three](https://user-images.githubusercontent.com/56315630/194468011-6b015d81-6e96-4b4a-846a-aff8910243dd.PNG)
![four](https://user-images.githubusercontent.com/56315630/194468017-5c2ac4b6-b8cd-4f75-8dbd-e46c0f6c9258.PNG)


