### PR TITLE
FIX prevent crash when no fail message

### DIFF
--- a/theia/autograde/anubis_autograde/exercise/verify.py
+++ b/theia/autograde/anubis_autograde/exercise/verify.py
@@ -32,7 +32,7 @@ def _r(
     if item is None:
         item = exercise
 
-    exercise_fail_message: str | None = getattr(item, f'{condition}_fail_message') or getattr(item, 'fail_message')
+    exercise_fail_message: str | None = getattr(item, f'{condition}_fail_message', None) or getattr(item, 'fail_message', None)
     if exercise_fail_message is None:
         raise RejectionException(default_message)
 


### PR DESCRIPTION
getattr raises AttributeError unless third parameter is provided. We don't want an exception here.

Sorry, should have caught this earlier.
<!--
Before submitting a pull request, please read
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#pull-requests

Commit message formatting guidelines:
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Include with development environment you are using.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
