### PR TITLE
CHG add ~/bin to user's PATH

### DIFF
--- a/theia/autograde/anubis_autograde/shell/bashrc.py
+++ b/theia/autograde/anubis_autograde/shell/bashrc.py
@@ -91,6 +91,7 @@ jrun() {
     esac
 }
 
+export PATH=${HOME}/bin:${PATH}
 rm -f /tmp/output
 
 set_ps1


### PR DESCRIPTION
We need ~/bin to be first in the PATH so that exercises can add programs that can be run by the user as part of the exercise

<!--
Before submitting a pull request, please read
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#pull-requests

Commit message formatting guidelines:
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Include with development environment you are using.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
