### PR TITLE
FIX remove "oh no" when there are no questions

### DIFF
--- a/web/src/components/core/Questions/Questions.jsx
+++ b/web/src/components/core/Questions/Questions.jsx
@@ -105,7 +105,7 @@ export default function Questions({assignment_id}) {
     return (
       <Box className={classes.emptyQuestions}>
         <Typography className={classes.emptyQuestionsText}>
-          Oh no! There are no questions for this assignment.
+          There are no questions for this assignment.
         </Typography>
       </Box>
     );


### PR DESCRIPTION
The "oh no!" message suggests an error, but the absence of questions on an assignment is not an error.

<!--
Before submitting a pull request, please read
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#pull-requests

Commit message formatting guidelines:
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Include with development environment you are using.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
