### PR TITLE
FIX do not mark late submissions for autograde disabled assignments as accepted

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Background API
       run: |
         set -ex
+        docker run -itd -p 6379:6379 redis redis-server --requirepass anubis
         env MINDEBUG=1 MIGRATE=1 ./venv/bin/python3 dev.py &
     - name: Test with pytest
       run: |

--- a/api/anubis/views/public/webhook.py
+++ b/api/anubis/views/public/webhook.py
@@ -173,7 +173,6 @@ def public_webhook():
     # If the github username is not found, create a dangling submission
     if not assignment.autograde_enabled:
         submission.processed = True
-        submission.accepted = True
         submission.state = AUTOGRADE_DISABLED_MESSAGE
 
     db.session.commit()


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#pull-requests

Commit message formatting guidelines:
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Include with development environment you are using.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
This also modifies a reaper job to get that fixed. One instance of this error would be [this](https://anubis-lms.io/courses/assignments/submissions?courseId=e271a4bc-8b5e-43eb-b2b2-15e922b8fa29&userId=3aef2252-d848-4a3e-b701-262b47127000). The student does not have late exceptions, while having a late submission, but that submission gets accepted anyway.