### PR TITLE
CHG Fira Code Font Loads From Google Fonts Instead Of Locally

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -17,6 +17,9 @@
     <meta property="og:image:secure_url" content="https://anubis.osiris.services/logo512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap" rel="stylesheet">  
     <title>Anubis LMS</title>
 </head>
 <body>

--- a/web/src/theme/Theme.jsx
+++ b/web/src/theme/Theme.jsx
@@ -1,5 +1,4 @@
 import {createTheme} from '@mui/material/styles';
-import FiraRegular from '../assets/fonts/FiraCode-Regular.ttf';
 
 
 const fira = {
@@ -7,10 +6,6 @@ const fira = {
   fontStyle: 'normal',
   fontDisplay: 'swap',
   fontWeight: 400,
-  src: `
-    local('Fira Code'),
-    url(${FiraRegular}) format('ttf')
-  `,
   unicodeRange:
     'U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, ' +
     'U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, ' +


### PR DESCRIPTION
Fira Code Not Showing Up Correctly

Seems to be an issue of the ttf not working on some windows? We can try using woff and woff2 files on top of ttf which works for apple devices.
Solved by using CDN instead.
If CDN is fine and we don't need self hosted, I will make a small follow-up to delete the locally hosted Fira-Code font files. 
<!--
Before submitting a pull request, please read
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#pull-requests

Commit message formatting guidelines:
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Include with development environment you are using.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
