### PR TITLE
fix: replace bare except with except Exception

### DIFF
--- a/api/anubis/utils/discord/webhook.py
+++ b/api/anubis/utils/discord/webhook.py
@@ -60,7 +60,7 @@ def send_webhook(content: str):
             },
             timeout=1.0
         )
-    except:
+    except Exception:
         logger.error(traceback.format_exc())
         return
 

--- a/api/anubis/views/admin/lectures.py
+++ b/api/anubis/views/admin/lectures.py
@@ -102,7 +102,7 @@ def admin_lecture_save(lecture_notes_id: str):
     if isinstance(post_time, str):
         try:
             post_time = date_parse(post_time)
-        except:
+        except Exception:
             post_time = None
 
     # Get lecture notes
@@ -170,7 +170,7 @@ def admin_lecture_upload():
     if isinstance(post_time, str):
         try:
             post_time = date_parse(post_time)
-        except:
+        except Exception:
             post_time = None
 
     # If post time is None for whatever reason, then


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` in webhook and lectures modules.

Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which is almost never intended. Using `except Exception:` follows PEP 8 best practices.

**Changes:**
```python
# Before (webhook.py:63)
except:
    logger.error(traceback.format_exc())

# After
except Exception:
    logger.error(traceback.format_exc())

# Before (lectures.py:105, 173)
except:
    post_time = None

# After
except Exception:
    post_time = None
```

## Files Changed
- `api/anubis/utils/discord/webhook.py` — 1 bare except → except Exception
- `api/anubis/views/admin/lectures.py` — 2 bare except → except Exception

## Testing
No behavior change for normal exceptions — style/correctness fix only.